### PR TITLE
Add STD-002 Draft: Standards Governance Policy

### DIFF
--- a/core/standards_governance_policy.md
+++ b/core/standards_governance_policy.md
@@ -1,0 +1,88 @@
+---
+id: STD-002
+title: Standards Governance Policy
+version: 1.0.0
+category: core
+status: draft
+last_updated: 2025-11-12
+extends: []
+tags: [governance, lifecycle, review, compliance, standards]
+---
+
+# Purpose
+This policy defines the governance framework for the creation, review, approval, versioning, and retirement of all documentation standards within the organizational repository. It ensures all standards are subject to a uniform lifecycle, enforced roles, and compliance expectations.  
+This document serves as the authoritative governance policy for managing the lifecycle of all future standards.
+
+# Scope
+This policy applies to all technical standards, policies, procedures, and governance documents maintained within the policies-and-standards repository. It defines mandatory roles, review workflows, versioning rules, and compliance mechanisms for any document governed under STD-001.
+
+# Standard
+
+## 1. Roles and Responsibilities
+
+1.1 Each standard MUST have one assigned **Owner** responsible for authorship and maintenance.  
+1.2 Each standard MUST be reviewed by at least one designated **Reviewer** to validate structure, content, and alignment with organizational principles.  
+1.3 Each standard MUST be approved by a designated **Approver**, accountable for final validation and publication.  
+1.4 Roles MAY be fulfilled by separate individuals or the same person if authorized under governance controls.  
+1.5 All role assignments MUST be documented in the version control system (e.g., commit authorship, pull request review).
+
+## 2. Document Lifecycle
+
+2.1 Standards MUST progress through the following lifecycle states:
+
+- `draft`: In development, not yet reviewed.  
+- `review`: Under formal review by Reviewer(s).  
+- `active`: Approved and in effect.  
+- `deprecated`: No longer in use; replaced or retired.
+
+2.2 Lifecycle status MUST be reflected in the `status` field of the YAML frontmatter.  
+2.3 Transitions between states MUST be tracked via pull requests, commit messages, or version control logs.  
+2.4 A document MAY return to `draft` or `review` status for amendment prior to re-approval.  
+2.5 Returning a document to draft or review does not alter its version unless structural or content changes are introduced.
+
+## 3. Versioning Rules
+
+3.1 All documents MUST use semantic versioning (`X.Y.Z`) in the `version` field.  
+3.2 The following version increments apply:
+
+- Increment `X` for major, breaking changes.  
+- Increment `Y` for minor changes that preserve structure.  
+- Increment `Z` for patches or metadata-only updates.
+
+3.3 Initial publication MUST begin at version `1.0.0`.  
+3.4 Each version increment MUST include a corresponding entry in the `# Changelog` section.
+
+## 4. Retirement and Deprecation
+
+4.1 A standard MAY be marked `deprecated` when it is:
+
+- Superseded by a newer standard.  
+- Obsolete due to operational or organizational changes.  
+- No longer relevant or in use.
+
+4.2 Deprecation MUST be reflected in the `status` metadata and explained in the changelog.  
+4.3 Deprecated standards MUST remain in the repository for audit and traceability purposes.  
+4.4 A deprecated standard MUST NOT be edited except to update its changelog or add a deprecation note.
+
+## 5. Compliance and Escalation
+
+5.1 All standards MUST comply with STD-001 (Documentation Standard) and STD-002 (this policy).  
+5.2 Failure to comply with lifecycle, versioning, or role enforcement MAY result in rejection from the repository.  
+5.3 Governance bodies or designated approvers MAY escalate non-compliance to organizational leadership.  
+5.4 In collaborative contexts, unresolved disputes between Reviewer and Approver may be escalated to a designated repository steward or governance body.  
+5.5 Persistent violations MAY result in revocation of authorship or approval permissions.
+
+# Implementation Notes
+- Templates and role assignment guidelines SHOULD be maintained in a supporting reference document.  
+- Review and approval MAY be documented via repository pull request workflow with associated status labels.  
+- Version changes SHOULD be reviewed as part of changelog validation prior to publication.  
+- Until further notice, the repository Owner is the sole Approver and final authority for all documentation decisions.  
+- This policy is intended to enable both human-readable governance and machine-auditable traceability.
+
+# Compliance
+All future standards and policy documents MUST comply with the lifecycle, role, and versioning structures defined in this policy. Deviations MUST be explicitly approved and documented as exceptions.
+
+# Changelog
+- 1.0.0 — Initial draft.
+
+Reference: core/standards_governance_policy.md (STD-002)


### PR DESCRIPTION
This pull request introduces the initial draft of STD‑002 Standards Governance Policy.
It defines the roles, lifecycle stages, versioning rules, deprecation process, and compliance requirements for all documentation standards managed in this repository.

Key Features:

Establishes governance roles: Owner, Reviewer, Approver

Defines standard document lifecycle: draft, review, active, deprecated

Enforces semantic versioning (X.Y.Z)

Outlines deprecation criteria and audit requirements

Includes compliance and escalation mechanisms

Fully conforms to STD‑001 formatting and metadata rules (validated via Codex and lint checks)

This document will govern the structure and approval workflow for all future standards published under this repository.

Closes #2