### PR TITLE
docs(std): add STD-061 session review standard and template

### DIFF
--- a/05_Dev_Workflows/session_review_standard.md
+++ b/05_Dev_Workflows/session_review_standard.md
@@ -1,0 +1,147 @@
+---
+id: STD-061
+title: Session Review and Retrospective Standard
+version: 0.1.0
+category: workflow
+status: draft
+owner: sh4i-yurei
+reviewer: sh4i-yurei
+approver: sh4i-yurei
+last_updated: 2026-02-14
+review_date: 2026-05-14
+extends: [STD-000, STD-004, STD-032]
+tags: [session, review, retrospective, ai, process-improvement]
+---
+
+# Purpose
+
+Define a structured retrospective practice for AI-assisted development
+sessions. Session handoffs
+([SDLC_With_AI](SDLC_With_AI.md), [session_handoff_tpl](../06_Projects/Templates/ai/session_handoff_tpl.md))
+preserve continuity between sessions but do not capture what was
+learned. This standard ensures that mistakes, process improvements, and
+team coordination insights are recorded and acted upon.
+
+# Scope
+
+Applies to all AI-assisted work sessions governed by
+[SDLC_With_AI](SDLC_With_AI.md) (STD-032).
+
+Excludes:
+
+- Session handoff artifacts (covered by TPL-PRJ-HANDOFF)
+- Incident postmortems (covered by the incident postmortem template)
+- Design postmortems (covered by the design postmortem template)
+
+# Standard
+
+## When to produce a session review
+
+- Agents MUST produce a session review at the end of every Tier 2+ work
+  session.
+- Agents SHOULD produce a session review for Tier 1 sessions that
+  reveal process issues or coordination failures.
+- Multi-instance sessions (two or more concurrent AI agents) MUST
+  include a coordination assessment in the review.
+
+## Storage and naming
+
+Session reviews are stored outside project repositories so they persist
+across repos and provide a unified view of agent performance.
+
+```text
+~/session-reviews/
+├── <project>/
+│   ├── YYYY-MM-DD_<project>_s<N>_review.md
+│   └── ...
+└── <other-project>/
+    └── ...
+```
+
+- Root folder: `~/session-reviews/`
+- One subfolder per project, matching the project's short name
+- File naming: `YYYY-MM-DD_<project>_s<N>_review.md`
+  - Date first for chronological sort
+  - Project name for identification and search
+  - Session number (`s<N>`) cross-references PLANS.md
+
+## Required content
+
+Every session review MUST contain the sections defined in
+[session_review_tpl](../06_Projects/Templates/ai/session_review_tpl.md)
+(TPL-PRJ-SESSION-REVIEW):
+
+1. **Session metadata** — date, project, session number, instances
+   used, approximate duration
+2. **Accomplishments** — issues resolved, PRs merged, milestones
+   reached
+3. **Failures** — what happened, severity (high/medium/low), root
+   cause, corrective action
+4. **Self-rating** — scored table (1-10) covering at minimum:
+   orchestration, code quality, communication, rule adherence
+5. **Lessons learned** — actionable takeaways, not vague observations
+6. **Action items** — checklist with owners where applicable
+
+## Review interview process
+
+The session review MUST be conducted as a conversational interview:
+
+1. The agent initiates the review by presenting a self-evaluation
+   covering accomplishments, failures, and a candid self-rating.
+2. The user provides feedback, corrections, and additional observations.
+3. The agent incorporates user feedback into the final review document.
+
+The review captures both perspectives. The agent MUST NOT produce a
+review without user input unless the user explicitly declines the
+interview.
+
+## Action item tracking
+
+- Action items from the review MUST be referenced in the next session's
+  handoff artifact or in the project's PLANS.md.
+- Unresolved action items carry forward to subsequent reviews until
+  closed.
+- If an action item results in a process change, it SHOULD be captured
+  as an update to the relevant standard or to the agent's MEMORY.md.
+
+## Multi-instance coordination assessment
+
+When a session uses two or more concurrent AI instances, the review MUST
+additionally assess:
+
+- Branch ownership discipline (were branches respected?)
+- File overlap prevention (were conflicts avoided?)
+- Communication effectiveness (were handoffs clear?)
+- Orchestration quality (was work distributed efficiently?)
+
+# Implementation Notes
+
+- The session review complements but does not replace the session
+  handoff artifact. Handoffs cover what to do next; reviews cover what
+  was learned.
+- Keep reviews concise. Link to PRs, issues, and design docs rather
+  than duplicating content.
+- Self-ratings should be honest. Inflated ratings defeat the purpose of
+  the retrospective. Rate relative to the session's complexity and the
+  agent's own standards.
+- The `~/session-reviews/` folder is not a git repository. Reviews are
+  local artifacts for the user and agent to reference across sessions.
+
+# Continuous Improvement and Compliance Metrics
+
+- Track whether action items from previous reviews are addressed in
+  subsequent sessions.
+- Monitor self-rating trends across sessions to identify persistent
+  weaknesses.
+- Review frequency: at minimum, verify that every Tier 2+ session
+  produces a review artifact.
+
+# Compliance
+
+A Tier 2+ session completed without a review artifact is non-compliant
+with this standard. Agents resuming work SHOULD check for a review from
+the previous session and reference any open action items.
+
+# Changelog
+
+- 0.1.0 — Initial draft. Based on Session 7 prototype review.

--- a/06_Projects/Templates/ai/session_review_tpl.md
+++ b/06_Projects/Templates/ai/session_review_tpl.md
@@ -1,0 +1,124 @@
+---
+id: TPL-PRJ-SESSION-REVIEW
+title: Session review template
+version: 0.1.0
+category: template
+status: active
+owner: sh4i-yurei
+reviewer: sh4i-yurei
+approver: sh4i-yurei
+last_updated: 2026-02-14
+extends: [STD-001, STD-004, STD-032, STD-061]
+tags: [template, ai, session, review, retrospective]
+---
+
+# Purpose
+
+Provide a structured template for end-of-session retrospective reviews
+so that lessons learned, mistakes, and process improvements are captured
+consistently across projects and sessions.
+
+# Scope
+
+Use at the end of any Tier 2+ AI-assisted work session per
+[session_review_standard](../../../05_Dev_Workflows/session_review_standard.md)
+(STD-061). Save as
+`~/session-reviews/<project>/YYYY-MM-DD_<project>_s<N>_review.md`.
+
+# Standard
+
+## Session review template
+
+```md
+# Session <N> Review — <project>
+
+| Field | Value |
+|-------|-------|
+| Date | <YYYY-MM-DD> |
+| Project | <project name> |
+| Session | <N> |
+| Instances | <count and roles, e.g., "3 (I1 orchestrator, I2 specs, I3 tests)"> |
+| Duration | <approximate duration> |
+
+## Accomplishments
+
+### Issues resolved
+
+- #<number> — <short description> (<instance>, <PR reference>)
+
+### Milestones
+
+- <milestone or phase transition reached>
+
+## Failures
+
+### <N>. <failure title> (severity: <high|medium|low>)
+
+**What happened**: <factual description>
+
+**Impact**: <consequences>
+
+**Root cause**: <why it happened>
+
+**Fix**: <corrective action taken or planned>
+
+## Self-rating
+
+| Area | Score | Notes |
+|------|-------|-------|
+| Orchestration and planning | <1-10> | <brief justification> |
+| Code and config quality | <1-10> | <brief justification> |
+| Communication | <1-10> | <brief justification> |
+| Rule adherence | <1-10> | <brief justification> |
+| Overall session | <1-10> | <brief justification> |
+
+## Lessons learned
+
+1. <Actionable takeaway>
+2. <Actionable takeaway>
+
+## Action items
+
+- [ ] <action item with owner if applicable>
+- [ ] <action item with owner if applicable>
+```
+
+## Multi-instance coordination addendum
+
+For sessions using two or more concurrent AI instances, append the
+following section after "Action items":
+
+```md
+## Coordination assessment
+
+| Area | Rating | Notes |
+|------|--------|-------|
+| Branch discipline | <good/fair/poor> | <details> |
+| File overlap prevention | <good/fair/poor> | <details> |
+| Communication | <good/fair/poor> | <details> |
+| Work distribution | <good/fair/poor> | <details> |
+```
+
+# Implementation Notes
+
+- The review is produced through a conversational interview between the
+  agent and user, not generated silently.
+- Keep entries concise. Link to PRs and issues rather than duplicating
+  details.
+- Self-ratings should be honest and calibrated to session complexity.
+- Action items carry forward to subsequent sessions until resolved.
+
+# Continuous Improvement and Compliance Metrics
+
+- Track action item closure rate across sessions.
+- Monitor self-rating trends for persistent patterns.
+
+# Compliance
+
+Tier 2+ sessions completed without a review artifact are non-compliant
+per [session_review_standard](../../../05_Dev_Workflows/session_review_standard.md)
+(STD-061).
+
+# Changelog
+
+- 0.1.0 — Initial draft. Structure based on Session 7 prototype.

--- a/INDEX.md
+++ b/INDEX.md
@@ -92,6 +92,7 @@ find the standard, workflow, or template you need.
 | [Vulnerability Management](05_Dev_Workflows/vulnerability-management-workflow.md) | STD-046 | Vulnerability identification, tracking, and remediation. |
 | [Repo Initialization Workflow](05_Dev_Workflows/project_repo_initialization_workflow.md) | STD-054 | How new project repositories are set up. |
 | [Governance Process Audit](05_Dev_Workflows/governance-process-audit-checklist.md) | STD-059 | Checklist for auditing governance compliance. |
+| [Session Review and Retrospective](05_Dev_Workflows/session_review_standard.md) | STD-061 | Structured end-of-session retrospectives for AI-assisted work. |
 
 ## 06 Templates
 
@@ -102,6 +103,8 @@ find the standard, workflow, or template you need.
 | [AI Context Pack](06_Projects/Templates/ai/ai_context_pack_tpl.md) | Bundle KB references, rules, and constraints for a task. |
 | [ExecPlan](06_Projects/Templates/ai/exec_plan_tpl.md) | Execution plan for complex AI-assisted work. |
 | [Repo Orientation Skill](06_Projects/Templates/ai/repo_orientation_skill_tpl.md) | Skill for automated repo context discovery. |
+| [Session Handoff](06_Projects/Templates/ai/session_handoff_tpl.md) | Structured handoff artifact for multi-session continuity. |
+| [Session Review](06_Projects/Templates/ai/session_review_tpl.md) | End-of-session retrospective per STD-061. |
 | [Skill Template](06_Projects/Templates/ai/skill_tpl.md) | Author agent skills per STD-058. |
 
 ### Architecture


### PR DESCRIPTION
## Summary

- New standard **STD-061** (`05_Dev_Workflows/session_review_standard.md`) — structured end-of-session retrospectives for Tier 2+ AI-assisted work
- New template **TPL-PRJ-SESSION-REVIEW** (`06_Projects/Templates/ai/session_review_tpl.md`) — consistent schema for review documents
- Updated **INDEX.md** with entries for both, plus missing session handoff template entry

Closes #21

## Why

Session handoffs (TPL-PRJ-HANDOFF) preserve continuity but not learning.
Mistakes, process improvements, and coordination insights were being
lost between sessions. Session 7 revealed this gap when a branch
contamination incident and repeated CI failures went unrecorded until
the user initiated an ad-hoc retrospective.

## Key normative requirements

- MUST produce a review at end of every Tier 2+ session
- Multi-instance sessions MUST include coordination assessment
- Review conducted as conversational interview (agent self-eval + user feedback)
- Action items carry forward until closed
- Storage: `~/session-reviews/<project>/YYYY-MM-DD_<project>_s<N>_review.md`

## KB citations

- STD-000 (Governance Overview) — root governance
- STD-004 (AI Assisted Development) — agent behavior constraints
- STD-032 (SDLC with AI) — session workflow, handoff requirements
- STD-001 (Documentation Standard) — document structure

## Test plan

- [x] `markdownlint-cli2` passes on all 3 files
- [x] `cspell` passes on all 3 files
- [x] Pre-commit hooks pass
- [x] Frontmatter follows STD-001 schema
- [x] Cross-references use correct relative paths
- [x] INDEX.md entries correctly placed in workflows and AI templates tables

## AI assistance

All changes authored by Claude Opus 4.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)