### PR TITLE
docs(std): add pipeline optimization section to STD-030

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -128,7 +128,9 @@
     "underspecified",
     "rustc",
     "hotfixes",
-    "WCAG"
+    "WCAG",
+    "lockfiles",
+    "Dockerfiles"
   ],
   "dictionaries": ["softwareTerms"]
 }

--- a/05_Dev_Workflows/CI_CD_Pipeline_Model.md
+++ b/05_Dev_Workflows/CI_CD_Pipeline_Model.md
@@ -440,7 +440,9 @@ Recommended cache paths by language:
 
 Independent validation gates SHOULD run in parallel. Gates A through F
 have no inter-gate dependencies and SHOULD execute concurrently within
-a single CI run.
+a single CI run. Gate G (AI review) is currently advisory and MAY run
+asynchronously or on a separate schedule, so it is excluded from
+these parallelism and performance budget requirements.
 
 Sub-jobs within a gate (e.g., Gate B's markdownlint, yamllint,
 link-check, cspell, and version-consistency) SHOULD also run in parallel
@@ -451,8 +453,13 @@ unless they share mutable state.
 Gates SHOULD be skipped when their inputs have not changed:
 
 - Gate A: skip for documentation-only changes (already implemented).
-- Gate C and D: skip when only documentation or configuration files
-  changed and no source code was modified.
+- Gate C and D: MAY be skipped only when the diff is limited to
+  documentation content (e.g., `docs/**`, `.github/ISSUE_TEMPLATE/**`)
+  and/or CI-only non-runtime configuration (e.g., `.github/workflows/**`,
+  lint/format configs used only in CI). They MUST NOT be skipped for
+  changes to dependency, tooling, or runtime configuration (e.g.,
+  `pyproject.toml`, `package.json`, lockfiles, Dockerfiles, or
+  application configs).
 - Gate F: skip for documentation-only changes.
 
 Conditional execution MUST NOT weaken enforcement — the gate matrix


### PR DESCRIPTION
## Summary

Add a pipeline optimization section to STD-030 (CI/CD Pipeline Model) covering
caching, parallelism, conditional execution, concurrency, performance budgets,
and build artifact promotion. Bumps STD-030 from v1.1.6 to v1.2.0.

## KB standards consulted

- STD-030 — CI/CD Pipeline Model (this document)
- STD-033 — Documentation Change Workflow

## Decision records

- Issue: #38

## Artifacts updated

- Design: N/A
- Spec: N/A
- Schema definition: N/A

## Tests and validation

- markdownlint: PASS
- cspell: PASS
- pre-commit: PASS (all hooks)

## Risk and operations

- Release impact: Documentation-only change to an existing standard
- Security considerations: N/A

## AI assistance

- Tools used: Claude Code (Opus 4.6)
- Validation performed: markdownlint, cspell, pre-commit hooks
- AI-generated scope: Pipeline optimization section content

## Checklist

- [x] CI gates passed (local)
- [x] Required docs updated
- [x] KB citations included
- [x] Rollback or recovery plan documented (if required): N/A — docs-only